### PR TITLE
Add missing QuartzCore dependency.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -25,6 +25,7 @@ objc_library(
         "FBSnapshotTestCase/Categories/*.h",
     ]),
     enable_modules = 1,
+    sdk_frameworks = ["QuartzCore"],
     visibility = ["//visibility:public"],
     deps = [":SnapshotTestCaseFrameworkHeaders"],
 )


### PR DESCRIPTION
The library requries QuartzCore for CALayer but was not linking against
it. This can cause client targets to fail linking because of missing
symbols.